### PR TITLE
Fix argument names in Continue functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ collage_generator_for_lastfm.py [-h] [--size SIZE] [--apikey APIKEY]
                                 [--period {forever,year,6month,3month,month,week}]
                                 [--layout {spiral,topleft}]
                                 [--update_images {auto,yes,no}]
-                                [--ignore]
+                                [--ignore_warnings]
                                 user width height
 
 

--- a/collage_generator_for_lastfm.py
+++ b/collage_generator_for_lastfm.py
@@ -100,7 +100,7 @@ def ParseInputOptions():
 				    'The ' + dim_labels[i] +
 				    ' entered is way too big. If you\'re serious about this you can modify the code to bypass this limitation')
 
-			Continue('The ' + dim_labels[i] + ' entered is pretty big. This may take a while', args.ignore)
+			Continue('The ' + dim_labels[i] + ' entered is pretty big. This may take a while', args.ignore_warnings)
 
 		elif dim[i] < 0:
 			raise ValueError('The ' + dim_labels[i] + ' can\'t be negative')
@@ -124,13 +124,13 @@ def ParseInputOptions():
 
 	# Check size
 	if args.size > 300:
-		Continue('Most album covers are not larger than 300px so the images may look blurry', args.ignore)
+		Continue('Most album covers are not larger than 300px so the images may look blurry', args.ignore_warnings)
 
 	elif args.size < 32:
 		if args.size < 0:
 			raise ValueError('The size can\'t be negative')
 
-		Continue('The album size is set very small', args.ignore)
+		Continue('The album size is set very small', args.ignore_warnings)
 
 	# Check period
 	period_mapping = {
@@ -163,7 +163,7 @@ def ParseInputOptions():
 		if args.jpeg_quality < 1:
 			raise ValueError('JPEG quality cannot be less than 1')
 
-		Continue('The JPEG quality is set very low', args.ignore)
+		Continue('The JPEG quality is set very low', args.ignore_warnings)
 
 	# Check PNG compression
 	if args.png_compression > 9:


### PR DESCRIPTION
`args.ignore` seems to shoud be `args.ignore_warnings`:

```
➜  Collage-Generator-for-Last.fm git:(master) ✗ python collage_generator_for_lastfm.py --filetype png --period 3month ~~redactedlastfmuser~~ 4700 3400 --size 512 -o lastfm.collage.4700x3400.3m.png
Traceback (most recent call last):
  File "/Users/piotr/Fiddles-src/Collage-Generator-for-Last.fm/collage_generator_for_lastfm.py", line 483, in <module>
    main()
  File "/Users/piotr/Fiddles-src/Collage-Generator-for-Last.fm/collage_generator_for_lastfm.py", line 369, in main
    args = ParseInputOptions()
  File "/Users/piotr/Fiddles-src/Collage-Generator-for-Last.fm/collage_generator_for_lastfm.py", line 127, in ParseInputOptions
    Continue('Most album covers are not larger than 300px so the images may look blurry', args.ignore)
```